### PR TITLE
Bugfix/null route value

### DIFF
--- a/src/Glassy.AspNetCore.Http/RequestParameterBuilder.cs
+++ b/src/Glassy.AspNetCore.Http/RequestParameterBuilder.cs
@@ -143,7 +143,6 @@ namespace Glassy.Http.AspNetCore
         ITokenExtractorBuilder<TParameter> IRequestParameterBuilder<TParameter>.FromRoute(string key, string value)
         {
             if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("Value cannot be null or whitespace.", nameof(key));
-            if (string.IsNullOrWhiteSpace(value)) throw new ArgumentException("Value cannot be null or whitespace.", nameof(value));
 
             const string extractsFrom = "route";
             TokenExtractorBuilder<TParameter> builder = new TokenExtractorBuilder<TParameter>(this,


### PR DESCRIPTION
Fixed a bug which prevents creating a parser for route values with a value of `null`